### PR TITLE
Purge function for sniffer MFCs

### DIFF
--- a/machines/rasppi89/socket_server.py
+++ b/machines/rasppi89/socket_server.py
@@ -28,9 +28,13 @@ class FlowControl(threading.Thread):
                 mfc = element.keys()[0]
                 print(element[mfc])
                 print('Queue: ' + str(qsize))
-                self.mks.set_flow(element[mfc], self.mfcs[mfc])
+                value, addr = element[mfc], self.mfcs[mfc]
+                if value >= 0: #interpret it as a flow value
+                    self.mks.set_flow(value, addr)
+                elif value < 0: #interpret as a purge time
+                    self.mks.purge(value, addr)
                 qsize = self.pushsocket.queue.qsize()
-
+                
             for mfc in self.mfcs:
                 print('!!!')
                 flow =  self.mks.read_flow(self.mfcs[mfc])


### PR DESCRIPTION
Fixed problem with last pull request. Now edited on top of most recent version of driver.
To recap:
Added the function Mks_G_Series.purge() function to PyExpLabSys/drivers/mks_g_series.py. The purge time is given as an argument.
    Edited FlowControl.run() in PyExpLabSys/machines/rasppi89/socket_server.py so that if the user inputs a positive number (in labview) it is interpreted normally as a flow value, but if the user enters a negative value, it is interpreted as a purge time.
