### PR TITLE
Handle encoding error in mks_g_series driver

### DIFF
--- a/PyExpLabSys/drivers/mks_g_series.py
+++ b/PyExpLabSys/drivers/mks_g_series.py
@@ -4,10 +4,13 @@ from __future__ import print_function
 import time
 import logging
 import serial
+import sys
+
 from PyExpLabSys.common.supported_versions import python2_and_3
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
 python2_and_3(__file__)
+
 
 class MksGSeries():
     """ Driver for G-series flow controllers from MKS """
@@ -35,7 +38,10 @@ class MksGSeries():
         self.ser.write(com_string)
         time.sleep(0.1)
         reply = self.ser.read(self.ser.inWaiting())
-        reply = reply.decode()
+        try:  #some MFC communication gives UnicodeDecodeError 
+            reply = reply.decode()
+        except UnicodeDecodeError:
+            return 'could not decode reply'
         if len(reply) == 0:
             LOGGER.warning('No such device')
         else:
@@ -100,8 +106,9 @@ class MksGSeries():
         self.comm(command1, addr)
         print('PURGING')
         time.sleep(abs(t))
-        self.comm(command2, addr)
         print('DONE PURGING')
+        self.comm(command2, addr)
+        print('NORMAL MODE')
 
     def read_flow(self, addr=254):
         """ Read the flow """

--- a/machines/rasppi89/socket_server.py
+++ b/machines/rasppi89/socket_server.py
@@ -25,7 +25,7 @@ class FlowControl(threading.Thread):
             #print qsize
             while qsize > 0:
                 element = self.pushsocket.queue.get()
-                mfc = element.keys()[0]
+                mfc = list(element.keys())[0]
                 print(element[mfc])
                 print('Queue: ' + str(qsize))
                 value, addr = element[mfc], self.mfcs[mfc]
@@ -57,7 +57,7 @@ Livesocket.start()
 
 i = 0
 MFCs = {}
-MKS = mks.Mks_G_Series(port=port)
+MKS = mks.MksGSeries(port=port)
 for i in range(1, 8):
     time.sleep(2)
     print('!')


### PR DESCRIPTION
In PyExpLabSys/drivers/mks_g_series.py, MksGSeries.com() now handles the error rather than crashing when the flow controller sends it a response it can't decode to ascii.
Also fixed the name of the MksGSeries class in macines/rasppi89/socket_server.py and made that script python3-compatible by converting a dict.keys() to list before indexing.