### PR TITLE
added measurement_type in the colour scheme for vim

### DIFF
--- a/.vim/syntax/channel.vim
+++ b/.vim/syntax/channel.vim
@@ -8,7 +8,7 @@ if exists("b:current_syntax")
 endif
 
 " Keywords
-syn keyword celBlockCmd port amp_range mass speed masslabel repeat_interval label host command
+syn keyword celBlockCmd port amp_range mass speed masslabel repeat_interval label host command measurement_type
 
 syn keyword TitelBlock autorange comment ms_channel meta_channel
 


### PR DESCRIPTION
 updated colour scheme to include "measurement_type" keyword in celBlockCmd (same as masslabel, speed, etc)