### PR TITLE
Feature/hardcode less

### DIFF
--- a/PyExpLabSys/drivers/vaisala_dmt143.py
+++ b/PyExpLabSys/drivers/vaisala_dmt143.py
@@ -1,0 +1,108 @@
+"""Driver for Vaisala DMT 143"""
+import time
+import serial
+
+
+class VaisalaDMT143():
+    """Driver for Vaisala DMT 143"""
+    def __init__(self, port):
+        self.serial = serial.Serial(
+            port,
+            baudrate=19200,
+            timeout=1,
+            parity=serial.PARITY_NONE,
+            stopbits=serial.STOPBITS_ONE,
+            bytesize=serial.EIGHTBITS
+        )
+
+    def comm(self, command):
+        """
+        Handle actual serial communication with instrument.
+        """
+        actual_command = (command + '\r').encode('ascii')
+        self.serial.write(actual_command)
+        time.sleep(1)
+        in_waiting = self.serial.inWaiting()
+        reply = self.serial.read(in_waiting).decode()
+        return reply
+
+    def device_information(self):
+        """
+        Return information about the device.
+        """
+        command = '?'
+        info_raw = self.comm(command)
+        info = info_raw.strip()
+        info = info.split('\n')
+        model = info[0].strip()
+        serial_nr = info[1].split(' ')[-1].strip()
+        pressure = info[13].split(' ')[-2].strip()
+
+        # for item in info:
+        #    print(item.strip())
+
+        info_dict = {
+            'model': model,
+            'serial_nr': serial_nr,
+            'pressure': pressure
+        }
+        return info_dict
+
+    def current_errors(self):
+        """
+        Repport current error message, empty string if no errors.
+        """
+        command = 'ERRS'
+        errors_raw = self.comm(command)
+        if 'No errors' in errors_raw:
+            error_list = ''
+        else:
+            error_list = errors_raw
+        return error_list
+
+    def set_reference_pressure(self, pressure: float):
+        """
+        Set reference pressure used for internal calculations.
+        """
+        command = 'XPRES {:.5f}'.format(pressure)
+        reply = self.comm(command)
+        print(reply)  # todo!
+
+    def water_level(self):
+        """
+        The actual measurements from the device.
+        """
+        command = 'SEND'
+        raw_value = self.comm(command)
+        # One could consider to use the FORMAT command
+        # to make the output less cryptic...
+        split_values = raw_value.split(' ')
+        dew_point = float(split_values[2])
+        dew_point_atm = float(split_values[6])
+        vol_conc = float(split_values[9])
+        return_dict = {
+            'dew_point': dew_point,
+            'dew_point_atm': dew_point_atm,
+            'vol_conc': vol_conc
+        }
+        return return_dict
+
+
+def main():
+    """
+    Main function, used only for test runs.
+    """
+    port = '/dev/ttyUSB0'
+    dmt = VaisalaDMT143(port=port)
+
+    # print(dmt.set_reference_pressure(1))
+    current_errors = dmt.current_errors()
+    if current_errors:
+        print('Error! ' + current_errors)
+
+    # print(dmt.device_information())
+    print(dmt.water_level())
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/pistatus.py
+++ b/bin/pistatus.py
@@ -267,7 +267,7 @@ def collect_timezone_info():
     """Collect information about the timezone setting"""
     tests = {
         'Time zone': 'Europe/Copenhagen',
-        'NTP synchronized': 'yes'
+        'synchronized': 'yes'
     }
     time_zone_lines = check_output(
         'export LC_ALL=C; timedatectl',

--- a/bin/pistatus.py
+++ b/bin/pistatus.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # pylint: disable=no-member,invalid-name,no-else-return,global-statement
 
-"""Small utility script to show commonly used status information about the Raspberry Pi
+"""Small utility script to show commonly used status info about the Raspberry Pi
 
 The information should be broken down into the following sections:
 
@@ -30,33 +30,28 @@ Check settings (only print if wrong)
 
 """
 
-from __future__ import print_function
 from time import time
 import os
-from os.path import expanduser, join, isdir, isfile, abspath
-from os import getlogin, listdir, sep, chdir, getcwd, popen, environ
 import sys
 import shutil
 import socket
+import pathlib
 import argparse
+
 from threading import Thread
 from textwrap import wrap
 from functools import partial
 from subprocess import check_output
-from PyExpLabSys.common.supported_versions import python2_and_3
+
 T0 = time()
-python2_and_3(__file__)
+
 try:
     import getpass
 except ImportError:
     pass
 
-if sys.version_info.major < 3:
-    print("This script is Python 3 or above only")
-    raise SystemExit(1)
-
 try:
-    if environ['TERM'] == 'screen':
+    if os.environ['TERM'] == 'screen':
         print("In screen. Do not run pistatus.")
         raise SystemExit(2)
 except KeyError:
@@ -66,15 +61,8 @@ except KeyError:
 COL = 80
 if sys.version_info.minor > 2:
     COL, _ = shutil.get_terminal_size((78, 40))
-else:
-    # This will most likely fail on non-Linux platforms, in that case
-    # just ignore and use default
-    try:
-        _, COL = [int(num) for num in popen('stty size', 'r').read().split()]
-    except:  # pylint: disable=bare-except
-        pass
-
 WIDTH = COL - 4
+
 
 # Parse args for possible other HOSTNAME
 def get_hostname():
@@ -92,14 +80,18 @@ def get_hostname():
         else:
             return pi
 
+
 # Machine folder
 HOSTNAME = get_hostname()
 
-PYEXPLABSYS_DIR = join(expanduser("~"), "PyExpLabSys")
-PYEXPLABSYS_DIR_EXISTS = os.path.isdir(PYEXPLABSYS_DIR)
-
-MACHINE_DIR = join(PYEXPLABSYS_DIR, 'machines', HOSTNAME)
-if not isdir(MACHINE_DIR):
+PYEXPLABSYS_DIR = pathlib.Path.home() / 'PyExpLabSys'
+MACHINE_DIR_OLD = PYEXPLABSYS_DIR / 'machines' / HOSTNAME
+MACHINE_DIR_NEW = pathlib.Path.home() / 'machines' / HOSTNAME
+if MACHINE_DIR_NEW.exists():
+    MACHINE_DIR = MACHINE_DIR_NEW
+elif MACHINE_DIR_OLD.exists():
+    MACHINE_DIR = MACHINE_DIR_OLD
+else:
     MACHINE_DIR = None
 
 # key width default
@@ -107,19 +99,21 @@ KEY_WIDTH = 16
 
 # Username
 try:
-    USERNAME = getlogin()
+    USERNAME = os.getlogin()
 except FileNotFoundError:
     USERNAME = getpass.getuser()
 
-SCREEN_FOLDER = join(abspath(sep), 'var', 'run', 'screen', 'S-' + USERNAME)
+SCREEN_FOLDER = pathlib.Path('/') / 'var' / 'run' / 'screen' / ('S-' + USERNAME)
 
 # Dict used to collect data from thread
 THREAD_COLLECT = {}
+
 
 # Utility functions
 def color_(line, color):
     """Print with ansi color"""
     return '\x1b[{}m{}\x1b[0m'.format(color, line)
+
 
 red = partial(color_, color='1;31')
 bold = partial(color_, color='1;37')
@@ -158,11 +152,9 @@ def machine_status():
     # Purpose
     purpose = 'N/A'
     if MACHINE_DIR:
-        try:
-            with open(join(MACHINE_DIR, 'PURPOSE')) as file_:
-                purpose = file_.read()
-        except IOError:
-            pass
+        purpose_file = MACHINE_DIR / 'PURPOSE'
+        if purpose_file.exists():
+            purpose = purpose_file.read_text()
 
     # The purpose files have had two different formats, check for the new one
     purpose_lines = purpose.split('\n')
@@ -174,7 +166,6 @@ def machine_status():
         if not purpose:
             purpose = purpose_lines[1].replace('purpose:', '').strip()
 
-
     spaces = ' ' * (KEY_WIDTH - 7)
     purpose_key = 'purpose' + spaces + ': '
     purpose_lines = wrap(purpose, WIDTH, initial_indent=purpose_key)
@@ -183,10 +174,12 @@ def machine_status():
         framed(line)
 
     # Has autostart
-    if MACHINE_DIR and isfile(join(MACHINE_DIR, 'AUTOSTART.xml')):
-        value_pair('Has autostart', YES)
-    else:
-        value_pair('Has autostart', 'NO')
+    if MACHINE_DIR:
+        autostart = MACHINE_DIR / 'AUTOSTART.xml'
+        if autostart.exists():
+            value_pair('Has autostart', YES)
+        else:
+            value_pair('Has autostart', 'NO')
 
 
 def collect_running_programs():
@@ -202,7 +195,7 @@ def running_programs():
     framed(bold('================'))
 
     try:
-        screens = listdir(SCREEN_FOLDER)
+        screens = os.listdir(SCREEN_FOLDER)
     except FileNotFoundError:
         screens = (())
     if screens:
@@ -231,12 +224,12 @@ def collect_last_commit():
     """Collect last commit"""
     # older gits did not have the -C options, to change current
     # working directory internally, so we have to do it manually
-    cwd = getcwd()
-    if not PYEXPLABSYS_DIR_EXISTS:
+    cwd = pathlib.Path.cwd()
+    if not PYEXPLABSYS_DIR.exists():
         THREAD_COLLECT['last_commit'] = red('No PyExpLabSys archive')
         return
 
-    chdir(PYEXPLABSYS_DIR)
+    os.chdir(PYEXPLABSYS_DIR)
     last_commit = check_output(
         'git log --date=iso -n 1 --pretty=format:"%ad"',
         shell=True,
@@ -244,24 +237,25 @@ def collect_last_commit():
     THREAD_COLLECT['last_commit'] = last_commit
 
     # Change cwd back
-    chdir(cwd)
+    os.chdir(cwd)
 
 
 def collect_git_status():
     """Collect git status"""
     # older gits did not have the -C options, to change current
     # working directory internally, so we have to do it manually
-    cwd = getcwd()
-    if not PYEXPLABSYS_DIR_EXISTS:
+    cwd = pathlib.Path.cwd()
+    if not PYEXPLABSYS_DIR.exists():
         THREAD_COLLECT['git_status'] = None
         return
 
-    chdir(PYEXPLABSYS_DIR)
+    os.chdir(PYEXPLABSYS_DIR)
     git_status = check_output('git status --porcelain', shell=True)
     THREAD_COLLECT['git_status'] = git_status
 
     # Change cwd back
-    chdir(cwd)
+    os.chdir(cwd)
+
 
 def collect_timezone_info():
     """Collect information about the timezone setting"""
@@ -287,6 +281,7 @@ def collect_timezone_info():
             break
 
     THREAD_COLLECT['timezone'] = status
+
 
 def time_zone():
     """Display time zone information"""
@@ -341,8 +336,8 @@ def main():
     # line, so we put the three calls to the command line out into
     # threads
     threads = []
-    for function in (collect_running_programs, collect_last_commit, collect_git_status,
-                     collect_timezone_info):
+    for function in (collect_running_programs, collect_last_commit,
+                     collect_git_status, collect_timezone_info):
         thread = Thread(target=function)
         thread.start()
         threads.append(thread)
@@ -351,7 +346,6 @@ def main():
     hline()
     framed(yellow('Raspberry Pi status ({})'.format(HOSTNAME)), align='^')
     hline()
-
 
     machine_status()
     framed('')

--- a/bootstrap/.pylintrc
+++ b/bootstrap/.pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=CVS
@@ -33,7 +30,7 @@ load-plugins=
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable=I0011,W0142
+disable=I0011
 
 
 [REPORTS]
@@ -41,14 +38,6 @@ disable=I0011,W0142
 # Set the output format. Available formats are text, parseable, colorized, msvs
 # (visual studio) and html
 output-format=text
-
-# Include message's id in output
-include-ids=no
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
 
 # Tells whether to display a full report or only the messages
 reports=no
@@ -60,10 +49,6 @@ reports=no
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
-
 
 [TYPECHECK]
 
@@ -74,10 +59,6 @@ ignore-mixin-members=yes
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
-
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
@@ -95,9 +76,6 @@ notes=FIXME,XXX,TODO
 
 # Required attributes for module, separated by a comma
 #required-attributes=
-
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,apply,input
 
 # Regular expression which should only match correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -209,9 +187,6 @@ max-locals=15
 
 # Maximum number of return / yield for function / method body
 max-returns=6
-
-# Maximum number of branch for function / method body
-max-branchs=12
 
 # Maximum number of statements in function / method body
 max-statements=50

--- a/bootstrap/bootstrap_linux.bash
+++ b/bootstrap/bootstrap_linux.bash
@@ -33,12 +33,12 @@ export PYTHONPATH=$HOME/PyExpLabSys
 stty -ixon
 
 machine_dir=$HOME/PyExpLabSys/machines/$HOSTNAME
-if [ -d $machin_dir ]; then
+if [ -d $machine_dir ]; then
     echo "Entering machine dir: $machine_dir"
     cd $machine_dir
 fi
 machine_dir=$HOME/machines/$HOSTNAME
-if [ -d $machin_dir ]; then
+if [ -d $machine_dir ]; then
     echo "Entering machine dir: $machine_dir"
     cd $machine_dir
 fi
@@ -157,7 +157,7 @@ if [ $1 == "bash" ] || [ $1 == "all" ];then
 	grep "pistatus" ~/.bashrc > /dev/null
 	if [ $? -ne 0 ];then
 	    echo 'machine_dir=$HOME/PyExpLabSys/machines/$HOSTNAME' >> ~/.bashrc
-	    echo 'if [ -d $machin_dir ]; then' >> ~/.bashrc
+	    echo 'if [ -d $machine_dir ]; then' >> ~/.bashrc
 	    echo '    echo "Entering machine dir: $machine_dir"' >> ~/.bashrc
 	    echo '    cd $machine_dir' >> ~/.bashrc
 	    echo 'fi' >> ~/.bashrc

--- a/bootstrap/bootstrap_linux.bash
+++ b/bootstrap/bootstrap_linux.bash
@@ -9,20 +9,19 @@
 # apt install packages line 1, general packages
 #
 # NOTE: python3 is not installed on lite raspbian image by default!!
-apt1="openssh-server emacs graphviz screen ntp python python3 i2c-tools vim-nox"
+apt1="openssh-server emacs graphviz screen python3 i2c-tools vim-nox"
 
 # apt install packages line 2, python extensions
 #
 # NOTE: This line used to contain colorama, but it is a dependency of
 # pip, so it will be installed anyway
-apt2="python-pip python-mysqldb python3-pip python-numpy python3-numpy"
+apt2="python3-pip python3-numpy"
 
 # apt install packages that has possibly changed name, written in list form and installed one at at time
-declare -a apt3=("libpython2.7-dev" "libpython3-dev" "python-dev" "python3-dev" "libmysqlclient-dev" "libmariadbclient-dev")
+declare -a apt3=("libpython3-dev" "python3-dev" "libmysqlclient-dev" "libmariadbclient-dev")
 
-# packages to be installe by pip
-pippackages="minimalmodbus==0.6 pyusb python-usbtmc pyserial pyyaml pylint chainmap"
-pip3packages="minimalmodbus==0.6 pyusb python-usbtmc pyserial pyyaml mysqlclient"
+# packages to be installed by pip
+pip3packages="minimalmodbus pyusb python-usbtmc pyserial pyyaml mysqlclient"
 # Put packages into this array, whose installation sometimes fail
 declare -a pip3problempackages=("pylint")
 
@@ -34,6 +33,11 @@ export PYTHONPATH=$HOME/PyExpLabSys
 stty -ixon
 
 machine_dir=$HOME/PyExpLabSys/machines/$HOSTNAME
+if [ -d $machin_dir ]; then
+    echo "Entering machine dir: $machine_dir"
+    cd $machine_dir
+fi
+machine_dir=$HOME/machines/$HOSTNAME
 if [ -d $machin_dir ]; then
     echo "Entering machine dir: $machine_dir"
     cd $machine_dir
@@ -57,7 +61,7 @@ alias python=\"/usr/bin/python3\"
 alias a=\"cd ~/PyExpLabSys/PyExpLabSys/apps\"
 alias c=\"cd ~/PyExpLabSys/PyExpLabSys/common\"
 alias d=\"cd ~/PyExpLabSys/PyExpLabSys/drivers\"
-alias m=\"if [ -d ~/PyExpLabSys/machines/\$HOSTNAME ];then cd ~/PyExpLabSys/machines/\$HOSTNAME; else cd ~/PyExpLabSys/machines; fi\"
+alias m=\"if [ -d ~/machines/\$HOSTNAME ];then cd ~/machines/\$HOSTNAME; else cd ~/machines; fi\"
 alias p=\"cd ~/PyExpLabSys/PyExpLabSys\"
 alias b=\"cd ~/PyExpLabSys/bootstrap\"
 alias s=\"screen -x\"
@@ -251,20 +255,6 @@ fi
 # Install extra packages with pip
 if [ $1 == "pip" ] || [ $1 == "all" ];then
     echo
-    # Test if pip is there
-    pip --version > /dev/null
-    if [ $? -eq 0 ];then
-	echobold "===> INSTALLING EXTRA PYTHON PACKAGES WITH PIP"
-	echoblue "---> $pippackages"
-	sudo pip install -U $pippackages
-	echogood "+++++> DONE"
-    else
-	echobad "pip not installed, run install step and then re-try pip step"
-    fi
-
-    echo
-
-
     # Test if pip3 is there
     PIPEXECUTABLE=`which pip3`
     if [ $? -ne 0 ];then


### PR DESCRIPTION
This PR is a step towards removing some of the hard-coded values that binds PyExpLabSys to Surfcat. Among the changes are:

 * Move the address and the name of the database to settings (example of settings file below)
 * Remove code to regarding Python 2 compatibility in the code that has been modified. Python 2 no longer exists and support has been removed. Remaining pieces of code will be removed as it is found.
 * Update bootstrap_linux to fit newer distributions and to adapt to the fact that Python 2 support has been removed
 * Adapt to the new policy, that the machines folder should no longer be part of PyExpLabSys, but should be separate projects for each user. Examples of independent machines implementations are referenced below. According to the convention, the machines folder should live in ~/machines/  . The current machines folder will be removed in a later PR.

This PR also happens to include a prototype for a driver for Vaisala DMT143 dew point sensor.


**Examples of machines repos**
https://github.com/nanomade/machines
https://github.com/robertjensen/machines

**Example of a configuration file**
`~/.config/PyExpLabSys/user_settings.yaml`

```
# PyExpLabSys settings defaults

# Common
sql_server_host: 'DBHOST'
sql_database: 'DBNAME'

common_sql_reader_user: 'reader'
common_sql_reader_password: 'reader'
# The host can be hostname or IP-address
common_liveserver_host: 'LIVE_HOST'
common_liveserver_port: 9767

# PyExpLabSys.common.utilities settings
util_log_warning_email: 'user@server.dk'
util_log_error_email: 'user@server.dk'
util_log_mail_host: 'smtp.server.dk'
```