### PR TITLE
Introducing invoke

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+invoke
+pylint
+pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool.pytest]
 # By default, run with verbose on and show detail for skipped and xfail tests.
 # The confcutdir argument tells pytest to load conftest.py starting from
 # the unittest directory

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,87 @@
+
+"""This module defines tasks for the tool runner `invoke`"""
+
+from pathlib import Path
+from shutil import rmtree, which
+from invoke import task
+
+THIS_DIR = Path(__file__).parent
+
+
+@task(aliases=["bd"])
+def build_docs(context):
+    """Build the (html) documentation"""
+    with context.cd(THIS_DIR / "doc"):
+        context.run("sphinx-build -b html -d build/doctrees source build/html")
+    print("The freshly built docs can be opened with `invoke open-docs`")
+
+
+@task(aliases=["od"])
+def open_docs(context):
+    """Open the docs and builds them first if necessary"""
+    if which("xdg-open") is None:
+        print(
+            "Cannot open docs without the `xdg-open` command. This likely "
+            "means you are on Windows, and a suitable alternative will have "
+            "to be implemented in `tasks.py` for Windows support"
+        )
+        return
+
+    index_path = THIS_DIR / "doc" / "build" / "html" / "index.html"
+    if not index_path.is_file():
+        build_docs(context)
+    with context.cd(THIS_DIR):
+        context.run(f"xdg-open {index_path}")
+
+        
+CLEAN_PATTERNS = ("__pycache__", "*.pyc", "*.pyo", ".mypy_cache", "build")
+
+
+@task(
+    aliases=["c"],
+    help={
+        "dryrun": (
+            "Only display the files and folders that would be deleted by the "
+            "cleanup, but do not actually delete them"
+        ),
+    },
+)
+def clean(context, dryrun=False):
+    """Clean the repository
+
+    Will remove all files and folders that contains the following patterns:
+    => {}
+    """
+    if dryrun:
+        print("CLEANING DRYRUN")
+    for clean_pattern in CLEAN_PATTERNS:
+        for cleanpath in THIS_DIR.glob("**/" + clean_pattern):
+            # Ignore stuff in .venv
+            if ".venv" in cleanpath.parts:
+                continue
+
+            if cleanpath.is_dir():
+                print("DELETE DIR :", cleanpath)
+                if not dryrun:
+                    rmtree(cleanpath)
+            else:
+                print("DELETE FILE:", cleanpath)
+                if not dryrun:
+                    cleanpath.unlink()
+
+
+clean.__doc__ = clean.__doc__.format(", ".join(CLEAN_PATTERNS))
+
+
+@task(aliases=["pylint", "l"])
+def lint(context):
+    """Run linting tool on all of PyExpLabSys"""
+    with context.cd(THIS_DIR):
+        context.run("pylint PyExpLabSys")
+
+
+@task(aliases=["pytest", "t"])
+def test(context):
+    """Run non-equipment dependent tests"""
+    with context.cd(THIS_DIR):
+        context.run("pytest --color yes tests/unittests/ tests/functional_test/")

--- a/tests/functional_test/common/test_sockets_pull.py
+++ b/tests/functional_test/common/test_sockets_pull.py
@@ -12,9 +12,16 @@ except ImportError:
 SocketServer.UDPServer.allow_reuse_address = True
 
 # Extra modules
-import mock
+from unittest import mock
 import pytest
 # Own imports
+from PyExpLabSys import settings
+
+SETTINGS = settings.Settings()
+SETTINGS.util_log_warning_email = "fake@non.com"
+SETTINGS.util_log_error_email = "fake@non.com"
+SETTINGS.util_log_mail_host = "non.com"
+
 import PyExpLabSys.common.sockets
 DATA = PyExpLabSys.common.sockets.DATA
 from PyExpLabSys.common.sockets import DataPullSocket, DateDataPullSocket
@@ -32,7 +39,7 @@ DEFAULT_PORTS = {
 DEFAULT_CODENAMES = ['Laser1', 'Laser2']
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def sock():
     """Client socket fixture"""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/tests/functional_test/common/test_sockets_push.py
+++ b/tests/functional_test/common/test_sockets_push.py
@@ -67,7 +67,7 @@ DATA_SETS['NONE'] = {'action': 'None'}
 
 
 ### Define fixtures
-@pytest.yield_fixture
+@pytest.fixture
 def sock():
     """Client socket fixture"""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -88,7 +88,7 @@ def raw_data(request):
     return DATA_SETS[data_dict_name], DATA_SETS[request.param]
 
 
-@pytest.yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def class_dps(request):
     """DataPushSocket fixture
 
@@ -147,7 +147,7 @@ def queue(request):
         return Queue.Queue()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def callback(request):  # pylint: disable=unused-argument
     """Generate a memory callback function and reset afterwards"""
     yield memory_callback

--- a/tests/unittests/common/test_sockets.py
+++ b/tests/unittests/common/test_sockets.py
@@ -7,12 +7,19 @@ from __future__ import unicode_literals, print_function
 
 import sys
 import time
-import mock
+from unittest import mock
 import json
 import collections
 import socket
 import pytest
 from numpy import isclose
+from PyExpLabSys import settings
+
+SETTINGS = settings.Settings()
+SETTINGS.util_log_warning_email = "fake@non.com"
+SETTINGS.util_log_error_email = "fake@non.com"
+SETTINGS.util_log_mail_host = "non.com"
+
 from PyExpLabSys.common import sockets
 from PyExpLabSys.common.sockets import (
     bool_translate, socket_server_status, PullUDPHandler, CommonDataPullSocket, DataPullSocket,
@@ -54,7 +61,7 @@ def mocket():
     return mock.MagicMock()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def sockets_data_single():
     """A fixture for replaced sockets.DATA with SINGLE_DATA"""
     old_data = sockets.DATA
@@ -63,7 +70,7 @@ def sockets_data_single():
     sockets.DATA = old_data
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def sockets_data_all():
     """A fixture for replaced sockets.DATA with ALL_DATA"""
     old_data = sockets.DATA
@@ -80,7 +87,7 @@ def server():
     return server_
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def pull_udp_handler(mocket, server):
     """A PullUDPHandler fixture"""
     # Since init on a handler calls handle, mock it out while initing, so that it can be tested
@@ -102,7 +109,7 @@ def cdps_init_args():
     }
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def udp_server():
     """A UDPServer fixure"""
     if sys.version_info[0] == 2:
@@ -113,7 +120,7 @@ def udp_server():
         with mock.patch('socketserver.UDPServer') as udp_server:
             yield udp_server
 
-@pytest.yield_fixture
+@pytest.fixture
 def clean_data():
     """A clean sockets.DATA fixture"""
     old_data = sockets.DATA
@@ -122,7 +129,7 @@ def clean_data():
     sockets.DATA = old_data
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def push_udp_handler(mocket, server):
     """An any request PushUDPHandler"""
     # mock handle, which is called at instantiate time, inside a try except
@@ -428,7 +435,7 @@ class TestCommonDataPullSocket(object):
         # Check init of timeouts
         if init_timeouts:
             # If timeouts is given as a single number, make a list
-            if not isinstance(timeouts, collections.Iterable):
+            if not isinstance(timeouts, collections.abc.Iterable):
                 timeouts = [timeouts] * len(CODENAMES)
             timeouts = dict(zip(CODENAMES, timeouts))
             assert config['timeouts'] == timeouts


### PR DESCRIPTION
This PR introduces support for invoke, which has become a completely indispensable part of my tool chain since my SurfCat days. "What is `invoke`?" I hear you ask.

 **`invoke` is a modern and cross-platform relative to `make` with tasks defined in Python.**

Where at least one important purpose `make` and therefore also of `invoke` is to have **one common entry point for tool running and maintenance automation**. 

Why no just `make`? Well precisely because it isn't cross platform and because it requires the definition of the tasks in shell script, which is a little weird on a Python project, since Python was after all created for system automation tasks, to which Guido felt neither shell script nor C was quite right.

Anyway, the tasks for invoke is defined in the `tasks.py` file in the root of the project. Tasks are defined by applying the `@task` decorator on a function. That's it. Any cross platform differences you may need, you just code them into the functions, although right now they are all Linux version.

To use his marvelous tools, just pip install invoke and ask it which tasks it knows about with `invoke --list`:
```bash
…/PyExpLabSys introducing_invoke v3.10.0 (PyExpLabSys) 
at 16:42:01 ❯ invoke --list
Available tasks:

  build-docs (bd)    Build the (html) documentation
  clean (c)          Clean the repository
  lint (l, pylint)   Run linting tool on all of PyExpLabSys
  open-docs (od)     Open the docs and builds them first if necessary
  test (pytest, t)   Run non-equipment dependent tests
```
(the names in parenthesis are aliases for the task names)

You can call help on any of the tasks:
```bash
…/PyExpLabSys introducing_invoke v3.10.0 (PyExpLabSys) 
at 16:48:56 ❯ invoke clean --help
Usage: inv[oke] [--core-opts] clean [--options] [other tasks here ...]

Docstring:
  Clean the repository

  Will remove all files and folders that contains the following patterns:
  => __pycache__, *.pyc, *.pyo, .mypy_cache, build

Options:
  -d, --dryrun   Only display the files and folders that would be deleted by the cleanup, but do not actually delete them
```

And finally of course run a task just with the task name (or one of its aliases) as an argument:
```bash
…/PyExpLabSys introducing_invoke v3.10.0 (PyExpLabSys) 
at 16:49:52 ❯ invoke clean
DELETE DIR : /home/kenneth/venv/PyExpLabSys/tests/functional_test/common/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/tests/functional_test/fileparsers/test_specs/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/tests/functional_test/fileparsers/test_chemstation/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/tests/tmp/sockets/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/tests/unittests/common/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/tests/equipment_test/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/tests/equipment_test/common/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/PyExpLabSys/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/PyExpLabSys/thirdparty/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/PyExpLabSys/drivers/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/PyExpLabSys/common/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/PyExpLabSys/file_parsers/__pycache__
DELETE DIR : /home/kenneth/venv/PyExpLabSys/doc/build
```

Just as with make, you can chain tasks, so that `invoke clean build-docs` will first clean out temp files and the build the docs. Also, like `make` the tasks can make use of each other internally. Finally, invoke has a shorthad alias `inv`, which along with the alises for the tasks means that the command above can be typed as `inv c bd`. As always with aliases, no-one will remember until after a while, but then `invoke --list` is your friend.

I suggest you glance the `tasks.py` to get a feel for how it works and looks and try it out.

Besides invoke, this PR also contains some modern python 3 fixes for the automated tests, which I can only assume has not been run in a while 👀.