### PR TITLE
Improvements to screen alias and pistatus

### DIFF
--- a/bootstrap/bootstrap_linux.bash
+++ b/bootstrap/bootstrap_linux.bash
@@ -57,7 +57,7 @@ alias d=\"cd ~/PyExpLabSys/PyExpLabSys/drivers\"
 alias m=\"if [ -d ~/machines/\$HOSTNAME ];then cd ~/machines/\$HOSTNAME; else cd ~/machines; fi\"
 alias p=\"cd ~/PyExpLabSys/PyExpLabSys\"
 alias b=\"cd ~/PyExpLabSys/bootstrap\"
-alias s=\"screen -x\"
+alias s=\"screen -x -p 0\"
 "
 
 # Usage string, edit if adding another section to the script


### PR DESCRIPTION
This PR has two changes:

- Using `s` should always enter window 0 of the available screen to make it more user friendly
- git checks in pistatus.py now checks both ~/PyExpLabSys and ~/machines