### PR TITLE
Communications collecting pyserial for functional tests

### DIFF
--- a/PyExpLabSys/auxiliary/communications_collecting_pyserial.py
+++ b/PyExpLabSys/auxiliary/communications_collecting_pyserial.py
@@ -1,0 +1,128 @@
+"""This module contains a drop-in replacement for pyserial.Serial which makes it possible to
+record communications
+
+"""
+from json import dump, load
+from pathlib import Path
+import base64
+from attr import define, asdict
+from serial import Serial
+
+
+@define
+class _Communication:
+    type: str
+    data: bytes
+
+    def as_json(self) -> dict[str, str]:
+        dict_ = asdict(self)
+        dict_["data"] = base64.standard_b64encode(dict_["data"]).decode("ascii")
+        return dict_
+
+    @classmethod
+    def from_json(cls, dict_: dict[str, str]) -> "_Communication":
+        dict_["data"] = base64.standard_b64decode(dict_["data"])
+        return cls(**dict_)
+
+
+class CommunicationsFaker(Exception):
+    """Error in the communications faker"""
+
+
+class CommunicationsCollectingSerial:
+    """A communications collection pyserial.Serial
+
+    Args:
+        args: args for pyserial.Serial
+        kwargs: kwargs for pyserial.Serial
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._serial = Serial(*args, **kwargs)
+        self._collected_coms = []
+
+    def read(self, size: int = 1) -> bytes:
+        """Read `size` bytes"""
+        data = self._serial.read(size)
+        self._collected_coms.append(_Communication("READ", data))
+        return data
+
+    def write(self, data: bytes) -> None:
+        """Write `data`"""
+        self._serial.write(data)
+        self._collected_coms.append(_Communication("WRITE", data))
+
+    def __getattr__(self, name):
+        """Return attribute from wrapped pyserial.Serial"""
+        return getattr(self._serial, name)
+
+    def reset_collected_coms(self) -> None:
+        """Reset the collected communications"""
+        self._collected_coms = []
+
+    def save_collected_coms(self, path: Path) -> None:
+        """Save the collected communications
+
+        Args:
+            path (Path): The path of the file to save to
+
+        """
+        collected_coms_as_json = [c.as_json() for c in self._collected_coms]
+        with open(path, "w") as file_:
+            dump(collected_coms_as_json, file_, indent=4)
+
+    def close(self) -> None:
+        """Close the underlying serial object"""
+        self._serial.close()
+
+
+class CommunicationsReplayingSerial:
+    """A pyserial.Serial faker replaying collected data"""
+
+    def __init__(self, *args, **kwargs):
+        self._collected_coms: list[_Communication] | None = None
+
+    def load_collected_coms(self, path) -> None:
+        with open(path) as file_:
+            collected_coms_as_jsonable = load(file_)
+        self._collected_coms = [_Communication.from_json(j) for j in collected_coms_as_jsonable]
+
+    def write(self, data) -> None:
+        try:
+            _com = self._collected_coms.pop(0)
+        except IndexError:
+            raise CommunicationsFaker("No more communications fragments")
+
+        assert _com.type == "WRITE", "Was expecting write at this point"
+        assert _com.data == data, "Incorrect data to be written"
+
+    def read(self, size: int = 1) -> bytes:
+        if size == 0 and (not self._collected_coms or self._collected_coms[0].type == "WRITE"):
+            return b""
+
+        try:
+            _com = self._collected_coms.pop(0)
+        except IndexError:
+            raise CommunicationsFaker("No more communications fragments")
+
+        if _com.type == "WRITE":
+            raise CommunicationsFaker("Was expecting write")
+
+        assert size == len(_com.data), "Incorrect data size"
+        return _com.data
+
+    @property
+    def in_waiting(self) -> int:
+        try:
+            _com = self._collected_coms[0]
+        except IndexError:
+            return 0
+
+        if _com.type == "WRITE":
+            return 0
+        else:
+            return len(_com.data)
+
+    def flush(self):
+        ...

--- a/doc/source/auxiliary.rst
+++ b/doc/source/auxiliary.rst
@@ -1,0 +1,10 @@
+*****************************
+Auxiliary Software Components
+*****************************
+
+.. The common components subpage has its own table of contents for everything
+.. that is below this level, which is contained in the files below.
+.. toctree::
+    :maxdepth: 4
+
+    auxiliary/communications_collecting_pyserial

--- a/doc/source/auxiliary/communications_collecting_pyserial.rst
+++ b/doc/source/auxiliary/communications_collecting_pyserial.rst
@@ -1,0 +1,89 @@
+
+*********************************************
+The communications_collecting_pyserial module
+*********************************************
+
+This module contains components to collect serial communications "traces" and replay them during
+tests.
+
+The :class:`.CommunicationsCollectingSerial` class is used as a drop-in replacement for
+:class:`pyserial.Serial` and will collect the communications traces, so they can be saved after the
+communication has ended. It is used along of this::
+
+    """Collect communications traces and results"""
+
+    from json import dump
+    from pathlib import Path
+
+    from serial import PARITY_NONE
+
+    from somemodule import SomeDriver
+    from PyExpLabSys.auxiliary.communications_collecting_pyserial import CommunicationsCollectingSerial
+
+    THIS_DIR = Path(__file__).parent
+    DATA_DIR = THIS_DIR / "serial_com_data_folder"
+    DATA_DIR.mkdir(exist_ok=True, parents=True)
+
+    com = CommunicationsCollectingSerial(
+        port="COM25",
+        baudrate=9600,
+        bytesize=8,
+        parity=PARITY_NONE,
+        stopbits=1,
+        xonxoff=False,
+    )
+    driver = SomeDriver(com, address=1)
+    collected_test_results = {}
+
+
+    # Collect return value and communications trace and save
+    collected_test_results["some_value"] = driver.get_some_value()
+    com.save_collected_coms(DATA_DIR / "some_value.trace")
+    com.reset_collected_coms()
+
+    # ... Collect more traces and results
+
+    # Save results
+    with open(DATA_DIR / "results.json", "w") as file_:
+        dump(collected_test_results, file_, indent=4)
+
+    com.close()
+
+The test around this collected data, using the :class:`.CommunicationsReplayingSerial` might look
+like this::
+
+    """Communications traces tests"""
+
+    from json import load
+    from pathlib import Path
+
+    from pytest import approx, fixture
+
+    from some_module import SomeDriver
+    from PyExpLabSys.auxiliary.communications_collecting_pyserial import CommunicationsReplayingSerial
+
+    THIS_DIR = Path(__file__).parent
+    DATA_DIR = THIS_DIR / "serial_com_data_folder"
+
+
+    @fixture
+    def test_data():
+        with open(DATA_DIR / "results.json") as file_:
+            return load(file_)
+
+
+    def test_get_value(test_data):
+        replaying_coms = CommunicationsReplayingSerial()
+        replaying_coms.load_collected_coms(DATA_DIR / "some_value.trace")
+        device = SomeDriver(replaying_coms, address=1)
+        # NOTE: The reading from the replaying coms has additional assert that the communications is as
+        # expected
+        assert device.get_some_value() == approx(test_data["some_value"])
+
+Auto-generated module documentation
+-----------------------------------
+
+.. automodule:: PyExpLabSys.auxiliary.communications_collecting_pyserial
+    :members:
+    :member-order: bysource
+    :show-inheritance:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -294,7 +294,11 @@ def skip(app, what, name, obj, skip_, options):  # pylint: disable=unused-argume
 def setup(app):
     """Make custom setup"""
     app.connect("autodoc-skip-member", skip)
-    app.add_stylesheet('theme_overrides.css')
+
+
+html_css_files = [
+    'theme_overrides.css',
+]
 
 
 # -- PyExpLabSys build hacks ---------------------------------------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -20,6 +20,7 @@ Contents:
    overview
    user_notes
    common
+   auxiliary
    file-parsers
    apps
    drivers


### PR DESCRIPTION
This PR adds a few classes which makes it possible to collect serial communications traces and write tests around them.

There are examples in the documentation that will hopefully show how to use them.

The logic of the replaying, what consitutes a failure and so on is not perfect, but I found this sufficient for our use.

The one aspect of this implementation that I'm not really happy about is that the communications traces are saved BASE64 encoded in a JSON file. This is annoying, as I would prefer them to be human readable. However, it was more important for me to have them in a structured format, where I can have several reads and writes in one file. Unfortunately the text encoding which would be perfect for this, which is ASCII when it is ASCII and hex codes when it is not, as far as I can tell doesn't exist, so I can't have both, resulting is this slightly annoying compromise.

