### PR TITLE
drivers/powerwalker_ethernet.py, fix parsing by preserving empty lines in UPS CGI output

### DIFF
--- a/PyExpLabSys/drivers/powerwalker_ethernet.py
+++ b/PyExpLabSys/drivers/powerwalker_ethernet.py
@@ -9,7 +9,6 @@ class PowerWalkerEthernet(object):
     values. SNMP could also be used, but apparently most values miss a
     digit compared to the internal tools.
     """
-
     def __init__(self, ip_address, read_old_events=True):
         if read_old_events:
             self.latest_event = datetime.datetime.min
@@ -17,9 +16,8 @@ class PowerWalkerEthernet(object):
             self.latest_event = datetime.datetime.now()
         self.ssh = paramiko.SSHClient()
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        self.ssh.connect(
-            ip_address, username='root', password='12345678', look_for_keys=False
-        )
+        self.ssh.connect(ip_address, username='root',
+                         password='12345678', look_for_keys=False)
 
     def _read_static_data(self):
         """
@@ -33,20 +31,20 @@ class PowerWalkerEthernet(object):
 
         lines = []
         for line in raw_lines:
-            if line.strip():
-                lines.append(line.strip())
+            # lines.append(line.strip())  # Removed line filtering to preserve indexes,
+            lines.append(line.strip())    # because those lines are not always empty
 
-        nominal_input = int(lines[4][0:3])
-        nominal_output = int(lines[4][4:])
+        nominal_input = int(lines[5][0:3])  # was index 4
+        nominal_output = int(lines[5][4:])  # was index 4
         values = {
-            'model': lines[2],
-            'version': lines[6],
+            'model': lines[3],  # was index 2
+            'version': lines[7],  # was index 6
             'nominal_input_voltage': nominal_input,
             'nominal_output_voltage': nominal_output,
-            'nominal_output_frequency': int(lines[10]) / 10.0,
-            'rated_battery_voltage': int(lines[12]) / 10.0,
-            'rated_va': int(lines[8]),
-            'rated_output_current': int(lines[11]) / 10.0,
+            'nominal_output_frequency': int(lines[11]) / 10.0,  # was index 10
+            'rated_battery_voltage': int(lines[13]) / 10.0,  # was index 12
+            'rated_va': int(lines[9]),  # was index 8
+            'rated_output_current': int(lines[12]) / 10.0  # was index 11
         }
         return values
 
@@ -55,7 +53,7 @@ class PowerWalkerEthernet(object):
         information = {
             'company': 'Power Walker',
             'model': statics['model'],
-            'version': statics['version'],
+            'version': statics['version']
         }
         return information
 
@@ -65,7 +63,7 @@ class PowerWalkerEthernet(object):
             'rated_voltage': statics['nominal_output_voltage'],
             'rated_current': statics['rated_output_current'],
             'battery_voltage': statics['rated_battery_voltage'],
-            'rated_frequency': statics['nominal_output_frequency'],
+            'rated_frequency': statics['nominal_output_frequency']
         }
         return ratings
 
@@ -76,28 +74,26 @@ class PowerWalkerEthernet(object):
 
         lines = []
         for line in raw_lines:
-            if line.strip():
-                lines.append(line.strip())
+            # lines.append(line.strip())  # Removed line filtering to preserve indexes,
+            lines.append(line.strip())    # because those lines are not always empty
 
-        status = []  # TODO!
-        if not lines[1] == 'Line Mode':
-            status.append('Utility Fail')  # Compatibility with serial interface
+        status = []
+        if not lines[2] == 'Line Mode':  # was index 1
+            status.append('Utility Fail')
 
         values = {
-            'input_voltage': int(lines[12]) / 10.0,
-            'output_voltage': int(lines[15]) / 10.0,
-            'output_current': int(lines[35]) / 10.0,
-            'input_frequency': int(lines[11]) / 10.0,
-            'battery_voltage': int(lines[8]) / 10.0,
-            'temperature': int(lines[2]) / 10.0,
+            'input_voltage': int(lines[15]) / 10.0,  # was index 12
+            'output_voltage': int(lines[18]) / 10.0,  # was index 15
+            'output_current': int(lines[38]) / 10.0,  # was index 35
+            'input_frequency': int(lines[14]) / 10.0,  # was index 11
+            'battery_voltage': int(lines[11]) / 10.0,  # was index 8
+            'temperature': int(lines[3]) / 10.0,  # was index 2
             'status': status,
-            'battery_capacity': int(lines[9]),
-            'remaining_battery': lines[10],  # minutes
-            'output_frequency': int(lines[14]) / 10.0,
-            'load_level': int(lines[17]),
+            'battery_capacity': int(lines[12]),  # was index 9
+            'remaining_battery': lines[13],  # was index 10
+            'output_frequency': int(lines[17]) / 10.0,  # was index 14
+            'load_level': int(lines[20])  # was index 17
         }
-        # WARNING (appears in web front-end - find how to read)
-        # FAULT (appears in web front-end - find how to read)
         return values
 
     def read_events(self, only_new=False):
@@ -112,18 +108,18 @@ class PowerWalkerEthernet(object):
         events = []
         for line in raw_lines[1:]:
             split_line = line.strip().split(',')
-            timestamp = datetime.datetime.strptime(split_line[0], '%Y/%m/%d %H:%M:%S')
+            timestamp = datetime.datetime.strptime(split_line[0],
+                                                   '%Y/%m/%d %H:%M:%S')
             if only_new and timestamp <= self.latest_event:
                 continue
             event = {
                 'timestamp': timestamp,
                 'event': split_line[1],
-                'source': split_line[2],
+                'source': split_line[2]
             }
             events.append(event)
             self.latest_event = timestamp
         return events
-
 
 if __name__ == '__main__':
     pw = PowerWalkerEthernet(ip_address='192.168.2.100')


### PR DESCRIPTION
Previously, the code removed empty lines from the output of the CGI scripts before parsing. This caused misalignment between the actual line numbers in the raw text files and the indexes used for data extraction, whenever the normally empty lines became non-empty, for example during an overload or battery dead condition.

This commit comments out the line that was stripping empty lines and updates the relevant line indexes accordingly to match the original file structure, ensuring correct parsing of all fields.