### PR TITLE
Implement optional substructure from hostname to machine_dir

### DIFF
--- a/bootstrap/bootstrap_linux.bash
+++ b/bootstrap/bootstrap_linux.bash
@@ -36,14 +36,41 @@ export PATH=$PATH:$HOME/PyExpLabSys/bin:$HOME/.local/bin:$HOME/machines/bin
 export PYTHONPATH=$PYTHONPATH:$HOME/PyExpLabSys:$HOME/machines
 stty -ixon
 
-machine_dir=$HOME/machines/$HOSTNAME
-if [ -d $machine_dir ]; then
-    echo "Entering machine dir: $machine_dir"
-    cd $machine_dir
+# Define and enter machine dir
+prefix=${HOSTNAME%%-*}             # everything before first -
+rest=${HOSTNAME#*-}               # remove prefix and first -
+setup=${rest%%-*}              # everything before next -
+end=${rest#*-} # everything after the next -
+
+if [ -d $HOME/machines/$HOSTNAME ]; then
+    machine_dir=$HOME/machines/$HOSTNAME
+elif [ -d $HOME/machines/$prefix/$setup-$end ]; then
+    machine_dir=$HOME/machines/$prefix/$setup-$end
+elif [ -d $HOME/machines/$prefix/$setup/$end ]; then
+    machine_dir=$HOME/machines/$prefix/$setup/$end
+elif [ -d $HOME/machines/$setup/$end ]; then
+    machine_dir=$HOME/machines/$setup/$end
+elif [ -d $HOME/machines/$setup-$end ]; then
+    machine_dir=$HOME/machines/$setup-$end
+elif [ -d $HOME/machines/$prefix-$setup ]; then
+    machine_dir=$HOME/machines/$prefix-$setup
+elif [ -d $HOME/machines/$prefix/$setup ]; then
+    machine_dir=$HOME/machines/$prefix/$setup
+else
+    machine_dir=$HOME/machines
 fi
+echo "Entering machine dir: $machine_dir"
+cd $machine_dir
+
+# Run pistatus
 pistatus.py
-if [ -f ~/'$PELS_ENV'/bin/activate ]; then
-    source ~/'$PELS_ENV'/bin/activate
+if [ -f ~/.pels/bin/activate ]; then
+    source ~/.pels/bin/activate
+fi
+
+# Reload aliases to exploit newly defined variable names
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
 fi
 '
 
@@ -56,7 +83,7 @@ alias emacs-nolint=\"emacs -q --load ~/PyExpLabSys/bootstrap/.emacs-simple\"
 alias a=\"cd ~/PyExpLabSys/PyExpLabSys/apps\"
 alias c=\"cd ~/PyExpLabSys/PyExpLabSys/common\"
 alias d=\"cd ~/PyExpLabSys/PyExpLabSys/drivers\"
-alias m=\"if [ -d ~/machines/\$HOSTNAME ];then cd ~/machines/\$HOSTNAME; else cd ~/machines; fi\"
+alias m=\"if [ -d $machine_dir ];then cd $machine_dir; fi\"
 alias p=\"cd ~/PyExpLabSys/PyExpLabSys\"
 alias b=\"cd ~/PyExpLabSys/bootstrap\"
 alias s=\"screen -x -p 0\"


### PR DESCRIPTION
An attempt at grouping machine directories in subfolders based on the hostname.

So for hostname xxx-yyy-zzz, the directory structure in $HOME/machines could be:

- xxx-yyy-zzz (unchanged)
- xxx/yyy-zzz
- xxx/yyy/zzz
- yyy/zzz
- yyy-zzz
- xxx/yyy

...and combinations like that. I've paid a little attention to the order of priority like respecting a match to the exact hostname first and putting the combinations with two elements later, but otherwise haven't tested extensively. Since a hostname should be unique in a machines environment, issues should only occur if multiple directory trajectories could match the hostname, which should only be the case during development or implementation of this.

There might be some PyExpLabSys functions that try to get the machine folder via hostname - I should check up on that before considering a merge here.